### PR TITLE
Add `repository` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
+  "repository": "cucapra/node-llvmc",
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "tsc"


### PR DESCRIPTION
This makes it a lot easier to find the repository, from the NPM package, to check out the referenced Examples among other things.